### PR TITLE
Alter how mixed results are added to trans-ethnic output in Bottom-Line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ target/
 .metals/
 .bloop/
 .vscode/
+.idea/
+*.iml


### PR DESCRIPTION
Mixed studies are often not used in the ancesstry-specific stage of bottom-line, and aren't ultimately combined into the trans-ethnic study until the loading step. Previously we incorrectly would only add variants unique to the various mixed studies not included in prior steps. Now it will add in the mixed results and, for each variant, choose the result with the largest n.

Testing: Ran against AST saving to a test bucket. Checked and confirmed that a number of variants found on the frontend are still there and that, where applicable, the large mixed dataset from Japan Biobank is now reported as the smallest p-value.

NOTE: Also adds some IntelliJ specific files to gitignore.