### PR TITLE
Fix cluster bootstrap

### DIFF
--- a/bioindex/src/main/resources/cluster-bootstrap.sh
+++ b/bioindex/src/main/resources/cluster-bootstrap.sh
@@ -10,7 +10,7 @@ sudo ln -s /usr/local/bin/pip /bin/pip
 sudo ln -s /usr/local/bin/pip3 /bin/pip3
 
 # bioindex to get access to shared library functions
-sudo pip3 install git+git://github.com/broadinstitute/dig-bioindex.git@master#egg=bioindex
+sudo pip3 install git+https://github.com/broadinstitute/dig-bioindex.git@master#egg=bioindex
 
 # other python libs used by various stages
 #


### PR DESCRIPTION
Looks like github finally pulled the plug on the git path for their urls. Similar to the Jenkins issue, since we only intend to pull from a public repo here using HTTPS will be fine.