### PR TITLE
[Bottom Line] Drop duplicate rows in clumping

### DIFF
--- a/bottom-line/src/main/resources/runPlink.py
+++ b/bottom-line/src/main/resources/runPlink.py
@@ -225,9 +225,8 @@ def merge_results():
     if not plink_files:
         return pd.DataFrame()
 
-    # join all the ancestries together (drop duplicates)
-    df = pd.concat(load_plink(o) for o in plink_files)\
-        .drop_duplicates()
+    # join all the ancestries together
+    df = pd.concat(load_plink(o) for o in plink_files)
 
     # build and process the connected graph for the clumps
     return build_graph(df)
@@ -354,6 +353,9 @@ def main():
 
     # sort by clump for easy debugging in S3
     clumped = clumped.sort_values('clump')
+
+    # As a final step drop duplicates
+    clumped = clumped.drop_duplicates()
 
     # write the output file and upload it
     clumped.to_json('variants.json', orient='records', lines=True)

--- a/bottom-line/src/main/resources/runPlink.py
+++ b/bottom-line/src/main/resources/runPlink.py
@@ -225,8 +225,9 @@ def merge_results():
     if not plink_files:
         return pd.DataFrame()
 
-    # join all the ancestries together
-    df = pd.concat(load_plink(o) for o in plink_files)
+    # join all the ancestries together (drop duplicates)
+    df = pd.concat(load_plink(o) for o in plink_files)\
+        .drop_duplicates()
 
     # build and process the connected graph for the clumps
     return build_graph(df)


### PR DESCRIPTION
Because we are analyzing all of the ancestries separately the same variant can be found multiple times. Here I just drop identical rows (which for TG seems to represent about a third of the data).

Alternatively, eventually we could instead add a new column (reference_ancestry) if we want to recover the individual ancestry data in the clumping.