### PR TITLE
[Bottom Line] Don't meta-analyze mixed ancestry studies

### DIFF
--- a/bottom-line/src/main/resources/runAncestrySpecific.sh
+++ b/bottom-line/src/main/resources/runAncestrySpecific.sh
@@ -31,10 +31,8 @@ fi
 # get all the unique ancestries
 ANCESTRIES=($(printf '%s\n' "${PARTS[@]}" | xargs dirname | xargs dirname | awk -F "=" '{print $NF}' | sort | uniq))
 
-# if there is more than one ancestry, don't process Mixed
-if [[ "${#ANCESTRIES[@]}" -gt 1 ]]; then
-  ANCESTRIES=($(printf '%s\n' "${ANCESTRIES[@]}" | grep -v Mixed))
-fi
+# Remove Mixed ancestry because we never want to run that through METAL
+ANCESTRIES=($(printf '%s\n' "${ANCESTRIES[@]}" | grep -v Mixed)) || ANCESTRIES=()
 
 # for each ancestry get all the datasets
 for ANCESTRY in "${ANCESTRIES[@]}"; do


### PR DESCRIPTION
For studies where there was only mixed datasets we previously would run those through METAL. This will now remove Mixed completely from the meta-analysis and add them back in only at the end.

Testing: Deleted the Mixed ancestry ancestry-specific results wherever found and reran the MetaAnalysisStage for all of those traits. Correctly did not produce meta-analyzed results for mixed ancestries, but the data appeared in the ultimate trans-ethnic data still (with a preference for the mixed dataset when sample sizes were equal).