### PR TITLE
[Bioindex] Add clump id to phewas assocations index

### DIFF
--- a/bioindex/README.md
+++ b/bioindex/README.md
@@ -99,7 +99,7 @@ The output of this stage is queried with the `global-associations` index.
 
 ### PhewasAssociationsStage
 
-The results of the bottom-line analysis are loaded, filtered by pValue, and grouped by variant ID before being written to `associations/phewas/...`.
+The results of the bottom-line analysis are loaded, joined to the clump ids, sorted by pValue, and grouped by variant ID before being written to `associations/phewas/...`.
 
 The output of this stage is queried with the `phewas-associations` index.
 

--- a/bioindex/src/main/resources/phewasAssociations.py
+++ b/bioindex/src/main/resources/phewasAssociations.py
@@ -9,10 +9,12 @@ def main():
 
     # load and output directory
     srcdir = f's3://dig-analysis-data/out/metaanalysis/trans-ethnic'
+    clumpdir = f's3://dig-analysis-data/out/metaanalysis/clumped'
     outdir = f's3://dig-bio-index/associations/phewas'
 
     # load all trans-ethnic, meta-analysis results for all variants
     df = spark.read.json(f'{srcdir}/*/part-*')
+    clump_df = spark.read.json(f'{clumpdir}/*/part-*')
 
     # limit the data being written
     df = df.select(
@@ -25,6 +27,14 @@ def main():
         df.stdErr,
         df.n,
     )
+
+    clump_df = clump_df.select(
+        clump_df.varId,
+        clump_df.phenotype,
+        clump_df.clump
+    )
+
+    df = df.join(clump_df, on=['varId', 'phenotype'], how='left')
 
     # write associations sorted by variant and then p-value
     df.orderBy(['chromosome', 'position', 'pValue']) \

--- a/bioindex/src/main/scala/PhewasAssociationsStage.scala
+++ b/bioindex/src/main/scala/PhewasAssociationsStage.scala
@@ -11,9 +11,10 @@ class PhewasAssociationsStage(implicit context: Context) extends Stage {
   import MemorySize.Implicits._
 
   val bottomLine = Input.Source.Success("out/metaanalysis/trans-ethnic/*/")
+  val clumped = Input.Source.Success("out/metaanalysis/clumped/*/")
 
   /** Input sources. */
-  override val sources: Seq[Input.Source] = Seq(bottomLine)
+  override val sources: Seq[Input.Source] = Seq(bottomLine, clumped)
 
   /** Rules for mapping input to outputs. */
   override val rules: PartialFunction[Input, Outputs] = {
@@ -24,8 +25,8 @@ class PhewasAssociationsStage(implicit context: Context) extends Stage {
   override val cluster: ClusterDef = super.cluster.copy(
     masterInstanceType = Ec2.Strategy.generalPurpose(mem = 64.gb),
     slaveInstanceType = Ec2.Strategy.generalPurpose(mem = 64.gb),
-    masterVolumeSizeInGB = 200,
-    slaveVolumeSizeInGB = 200,
+    masterVolumeSizeInGB = 250,
+    slaveVolumeSizeInGB = 250,
     instances = 6
   )
 


### PR DESCRIPTION
Joins with the clumping results to add the clumpid (if it exists) to the phewas data.

Currently if there is no clump that field doesn't exist. Increases master and slave memory on the EMR job by 50GB. So now this job can only run after both the MetaAnalysisStage and ClumpingStage run in Bottom Line.