### PR TITLE
[Bottom-line] Use trans-ethnic results in plink (clumping)

### DIFF
--- a/bottom-line/src/main/resources/runPlink.py
+++ b/bottom-line/src/main/resources/runPlink.py
@@ -51,8 +51,8 @@ def load_bottom_line(s3_dir):
     df = pd.concat([pd.read_json(fn, dtype={'pValue': np.float64}, lines=True) for fn in glob.glob('part-*')])
     df = df[['varId', 'pValue']]
 
-    # explode varId to get chrom, pos, ref, and alt
-    df[['chromosome', 'position', 'reference', 'alt']] = df['varId'].str.split(':', expand=True)
+    # explode varId to get chrom, pos, ref, and alt (alt will be catch all for everything else in the string)
+    df[['chromosome', 'position', 'reference', 'alt']] = df['varId'].str.split(':', n=3, expand=True)
 
     # drop unnecessary columns and cast types
     df = df.drop(['reference', 'alt'], axis=1)


### PR DESCRIPTION
The change to correct the error with the way mixed ancestry studies were combined with ancestry specific studies broke clumping which used the staging results (out of METAL) as an input.

IMO nothing in the staging directories should be used for anything but (maybe) the bioindex. Even there, since mixed ancestries don't go through metal the staging directories can be missing a decent amount of relevant data.

The corrects it for clumping by instead using the final tran-ethnic output as the input to clumping. I also added a guard against there being incorrect varIds which broke the run for TG (e.g.).