### PR TITLE
[Gregor] Replace invalid 0.0 underflow pValues with smallest np.int64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ target/
 .vscode/
 .idea/
 *.iml
+project/
+*/.aggregator/

--- a/gregor/src/main/resources/loadSummaries.py
+++ b/gregor/src/main/resources/loadSummaries.py
@@ -3,6 +3,8 @@ import os
 import re
 import subprocess
 
+import numpy as np
+
 from pyspark.sql import SparkSession
 from pyspark.sql.types import StructType, StructField, StringType, DoubleType, IntegerType
 from pyspark.sql.functions import col, input_file_name, lit, udf, when
@@ -68,6 +70,9 @@ def main():
             col('expectedSNPs'),
             col('pValue'),
         )
+
+    # Set min pValue to smalled numpy 64-bit value (in lieu of forking Gregor)
+    df = df.withColumn('pValue', when(df.pValue == 0.0, np.nextafter(0, 1)).otherwise(df.pValue))
 
     # remove NA results and write
     df.dropna() \


### PR DESCRIPTION
Small fix to account for the fact that GREGOR sets values below the smallest 64-bit float to 0.0 explicitly.