### PR TITLE
Associations bioindex memory bump

### DIFF
--- a/bioindex/src/main/scala/AssociationsStage.scala
+++ b/bioindex/src/main/scala/AssociationsStage.scala
@@ -24,7 +24,7 @@ class AssociationsStage(implicit context: Context) extends Stage {
   override val cluster: ClusterDef = super.cluster.copy(
     masterInstanceType = Ec2.Strategy.memoryOptimized(mem = 128.gb),
     masterVolumeSizeInGB = 200,
-    slaveVolumeSizeinGB = 64,
+    slaveVolumeSizeInGB = 64,
     bootstrapScripts = Seq(new BootstrapScript(resourceUri("cluster-bootstrap.sh")))
   )
 

--- a/bioindex/src/main/scala/AssociationsStage.scala
+++ b/bioindex/src/main/scala/AssociationsStage.scala
@@ -24,6 +24,7 @@ class AssociationsStage(implicit context: Context) extends Stage {
   override val cluster: ClusterDef = super.cluster.copy(
     masterInstanceType = Ec2.Strategy.memoryOptimized(mem = 128.gb),
     masterVolumeSizeInGB = 200,
+    slaveVolumeSizeinGB = 64,
     bootstrapScripts = Seq(new BootstrapScript(resourceUri("cluster-bootstrap.sh")))
   )
 


### PR DESCRIPTION
FGadjBMI was causing issues with a container falling over. Phewas experiences suggested this was a simple memory bump to fix and it worked.