### PR TITLE
PS input zstd 1

### DIFF
--- a/bioindex/src/main/resources/cluster-bootstrap-6.7.0.sh
+++ b/bioindex/src/main/resources/cluster-bootstrap-6.7.0.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -xe
+
+sudo yum install -y git
+
+# bioindex to get access to shared library functions
+sudo pip3 install git+https://github.com/broadinstitute/dig-bioindex.git@master#egg=bioindex
+
+# other python libs used by various stages
+#
+#Uninstall numpy so any system-wide numpy version won't conflict with the one Pandas pulls in
+sudo pip3 uninstall --yes numpy
+#Fix versions to make this more deterministic
+sudo pip3 install matplotlib==3.4.2
+sudo pip3 install pandas==1.2.5
+sudo pip3 install statsmodels==0.12.2
+
+sudo yum install -y zstd

--- a/bioindex/src/main/scala/DatasetAssociationsStage.scala
+++ b/bioindex/src/main/scala/DatasetAssociationsStage.scala
@@ -25,7 +25,7 @@ class DatasetAssociationsStage(implicit context: Context) extends Stage {
     masterInstanceType = Ec2.Strategy.memoryOptimized(),
     masterVolumeSizeInGB = 200,
     bootstrapScripts = Seq(new BootstrapScript(resourceUri("cluster-bootstrap-6.7.0.sh"))),
-    releaseLabel = ReleaseLabel("emr-6.7.0") // Need emr 6.1+ to write json files properly
+    releaseLabel = ReleaseLabel("emr-6.7.0") // Need emr 6.1+ to read zstd files
   )
 
   /** Output to Job steps. */

--- a/bioindex/src/main/scala/DatasetAssociationsStage.scala
+++ b/bioindex/src/main/scala/DatasetAssociationsStage.scala
@@ -24,7 +24,8 @@ class DatasetAssociationsStage(implicit context: Context) extends Stage {
   override val cluster: ClusterDef = super.cluster.copy(
     masterInstanceType = Ec2.Strategy.memoryOptimized(),
     masterVolumeSizeInGB = 200,
-    bootstrapScripts = Seq(new BootstrapScript(resourceUri("cluster-bootstrap.sh")))
+    bootstrapScripts = Seq(new BootstrapScript(resourceUri("cluster-bootstrap-6.7.0.sh"))),
+    releaseLabel = ReleaseLabel("emr-6.7.0") // Need emr 6.1+ to write json files properly
   )
 
   /** Output to Job steps. */

--- a/bottom-line/src/main/resources/cluster-bootstrap.sh
+++ b/bottom-line/src/main/resources/cluster-bootstrap.sh
@@ -3,30 +3,31 @@
 METAL_ROOT=/mnt/var/metal
 
 # create a gregor directory in /mnt/var to copy data locally
-mkdir -p "${METAL_ROOT}"
-chmod 775 "${METAL_ROOT}"
+sudo mkdir -p "${METAL_ROOT}"
+sudo chmod 775 "${METAL_ROOT}"
 
 # install to the metal directory
 cd "${METAL_ROOT}"
 
 # make sure a bin folder exists for the hadoop user
-mkdir -p /home/hadoop/bin
-mkdir -p /home/hadoop/scripts
+sudo mkdir -p /home/hadoop/bin
+sudo mkdir -p /home/hadoop/scripts
 
 # get a pre-built version of metal from S3
-aws s3 cp s3://dig-analysis-data/bin/metal/metal-2022-09-16.tgz /home/hadoop
-tar zxf /home/hadoop/metal-2022-09-16.tgz -C /home/hadoop
+sudo aws s3 cp s3://dig-analysis-data/bin/metal/metal-2022-09-16.tgz /home/hadoop
+sudo tar zxf /home/hadoop/metal-2022-09-16.tgz -C /home/hadoop
 
 # install it to the bin folder for use and make it executable
-ln -s /home/hadoop/metal/build/metal/metal /home/hadoop/bin/metal
+sudo ln -s /home/hadoop/metal/build/metal/metal /home/hadoop/bin/metal
 
 # copy the getmerge-strip-headers shell script from S3
-aws s3 cp "s3://dig-analysis-data/resources/scripts/getmerge-strip-headers.sh" /home/hadoop/bin
-chmod +x /home/hadoop/bin/getmerge-strip-headers.sh
+sudo aws s3 cp "s3://dig-analysis-data/resources/scripts/getmerge-strip-headers.sh" /home/hadoop/bin
+sudo chmod +x /home/hadoop/bin/getmerge-strip-headers.sh
 
 # copy the runMETAL script from S3
-aws s3 cp "s3://dig-analysis-data/resources/pipeline/metaanalysis/runMETAL.sh" /home/hadoop/bin
-chmod +x /home/hadoop/bin/runMETAL.sh
+sudo aws s3 cp "s3://dig-analysis-data/resources/pipeline/metaanalysis/runMETAL.sh" /home/hadoop/bin
+sudo chmod +x /home/hadoop/bin/runMETAL.sh
 
 # install jq to convert from json to tsv
 sudo yum install -y jq
+sudo yum install -y zstd

--- a/bottom-line/src/main/scala/MetaAnalysisStage.scala
+++ b/bottom-line/src/main/scala/MetaAnalysisStage.scala
@@ -46,7 +46,8 @@ class MetaAnalysisStage(implicit context: Context) extends Stage {
     slaveInstanceType = Strategy.memoryOptimized(mem = 128.gb),
     masterVolumeSizeInGB = 800,
     instances = 4,
-    bootstrapScripts = Seq(new BootstrapScript(resourceUri("cluster-bootstrap.sh")))
+    bootstrapScripts = Seq(new BootstrapScript(resourceUri("cluster-bootstrap.sh"))),
+    releaseLabel = ReleaseLabel("emr-6.7.0") // Need emr 6.1+ to read zstd files
   )
 
   /** Additional resources to upload. */

--- a/intake/src/main/resources/processor_bootstrap.sh
+++ b/intake/src/main/resources/processor_bootstrap.sh
@@ -13,6 +13,7 @@ rm var_to_af.zip
 
 # install dependencies
 sudo yum install -y python3-devel
+sudo yum install -y zstd
 sudo pip3 install -U boto3
 sudo pip3 install -U sqlalchemy
 sudo pip3 install -U pymysql

--- a/intake/src/main/resources/variantProcessor.py
+++ b/intake/src/main/resources/variantProcessor.py
@@ -574,7 +574,8 @@ class DataIntake:
 
 
 def upload_and_delete_files(path_to_file, filename, output_name, log_name):
-    subprocess.check_call(['aws', 's3', 'cp', output_name, f'{s3_output}/{path_to_file}/'])
+    subprocess.check_call(['zstd', output_name])
+    subprocess.check_call(['aws', 's3', 'cp', f'{output_name}.zst', f'{s3_output}/{path_to_file}/'])
     subprocess.check_call(['aws', 's3', 'cp', 'metadata', f'{s3_output}/{path_to_file}/'])
     subprocess.check_call(['aws', 's3', 'cp', log_name, f'{s3_output}/{path_to_file}/'])
     os.remove(output_name)

--- a/intake/src/main/resources/variantScaling.py
+++ b/intake/src/main/resources/variantScaling.py
@@ -141,6 +141,7 @@ def write_to_s3(outdir, logger, df):
     df.write \
         .mode('overwrite') \
         .option("ignoreNullFields", "false") \
+        .option("compression", "org.apache.hadoop.io.compress.ZStandardCodec") \
         .json(outdir)
 
     logger.save()

--- a/vep/src/main/resources/list-variant-bootstrap.sh
+++ b/vep/src/main/resources/list-variant-bootstrap.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -xe
+
+sudo yum install -y zstd

--- a/vep/src/main/scala/ListVariantsStage.scala
+++ b/vep/src/main/scala/ListVariantsStage.scala
@@ -27,7 +27,9 @@ class ListVariantsStage(implicit context: Context) extends Stage {
     slaveInstanceType = Ec2.Strategy.memoryOptimized(mem = 64.gb),
     masterVolumeSizeInGB = 400,
     slaveVolumeSizeInGB = 400,
-    instances = 8
+    instances = 8,
+    bootstrapScripts = Seq(new BootstrapScript(resourceUri("list-variant-bootstrap.sh"))),
+    releaseLabel = ReleaseLabel("emr-6.7.0") // Need emr 6.1+ to read zstd files
   )
 
   /** Map inputs to outputs. */


### PR DESCRIPTION
Swaps over to zstd compression in the intake line. Also fixes the three jobs that read in that output:
1) bottom line
2) dataset associations (bioindex)
3) vep

All work and running tests all are either identical in timing or, in the case of VEP, significantly faster.