### PR TITLE
[600k] Use new file to map to position and type

### DIFF
--- a/bioindex/src/main/resources/geneAssociations.py
+++ b/bioindex/src/main/resources/geneAssociations.py
@@ -49,11 +49,11 @@ def process_600trait_datasets(spark):
     df = spark.read.json('s3://dig-analysis-data/gene_associations/600k_600traits/*/*/part-*')
 
     df = df.withColumn('pValue', when(df.pValue == 0.0, np.nextafter(0, 1)).otherwise(df.pValue))
-    genes = spark.read.json('s3://dig-analysis-data/genes/GRCh37/part-*')
+    genes = spark.read.json('s3://dig-analysis-data/genes/ensembl/ensembl_gene_data.json')
 
     # fix for join
     genes = genes.select(
-        genes.name.alias('ensemblId'),
+        genes.ensemblId,
         genes.chromosome,
         genes.start,
         genes.end,


### PR DESCRIPTION
This file is a map between ensembl ids to position and gene type for use, currently, with the 600k data. Reduces the missing genes from the 600k bioindexes from around 600 to 30, and those 30 are ideally to be excluded from Hg37 data I think.