### PR TITLE
[Bottom Line] Partition output zstd, downstream uses compressed data

### DIFF
--- a/bioindex/src/main/scala/VariantAssociationsStage.scala
+++ b/bioindex/src/main/scala/VariantAssociationsStage.scala
@@ -27,7 +27,8 @@ class VariantAssociationsStage(implicit context: Context) extends Stage {
     masterVolumeSizeInGB = 200,
     slaveVolumeSizeInGB = 200,
     instances = 10,
-    bootstrapScripts = Seq(new BootstrapScript(resourceUri("cluster-bootstrap.sh")))
+    bootstrapScripts = Seq(new BootstrapScript(resourceUri("cluster-bootstrap-6.7.0.sh"))),
+    releaseLabel = ReleaseLabel("emr-6.7.0") // Need emr 6.1+ to read zstd files
   )
 
   /** Output to Job steps. */

--- a/bottom-line/src/main/resources/cluster-bootstrap.sh
+++ b/bottom-line/src/main/resources/cluster-bootstrap.sh
@@ -24,6 +24,10 @@ sudo ln -s /home/hadoop/metal/build/metal/metal /home/hadoop/bin/metal
 sudo aws s3 cp "s3://dig-analysis-data/resources/scripts/getmerge-strip-headers.sh" /home/hadoop/bin
 sudo chmod +x /home/hadoop/bin/getmerge-strip-headers.sh
 
+# copy the getmerge-strip-headers-zstd shell script from S3
+sudo aws s3 cp "s3://dig-analysis-data/resources/scripts/getmerge-strip-headers-zstd.sh" /home/hadoop/bin
+sudo chmod +x /home/hadoop/bin/getmerge-strip-headers-zstd.sh
+
 # copy the runMETAL script from S3
 sudo aws s3 cp "s3://dig-analysis-data/resources/pipeline/metaanalysis/runMETAL.sh" /home/hadoop/bin
 sudo chmod +x /home/hadoop/bin/runMETAL.sh

--- a/bottom-line/src/main/resources/getmerge-strip-headers-zstd.sh
+++ b/bottom-line/src/main/resources/getmerge-strip-headers-zstd.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+if [[ ! $# -eq 2 ]]; then
+  echo "Usage: merge.sh <hdfs-glob> <local-file>"
+  exit 1
+fi
+
+# extract parameters
+glob=$1
+outfile=$2
+
+# download files
+mkdir -p tmp_files
+aws s3 cp $glob ./tmp_files/ --recursive
+zstd -d --rm ./tmp_files/part-*
+
+# merge files
+cat ./tmp_files/part-* > "$outfile"
+rm -r tmp_files
+
+# discover the header to skip it later
+header=$(head -n 1 "$outfile")
+
+# where to do temporary file processing
+tmp="$(dirname "$outfile")/tmp.csv"
+
+# run awk to remove extra CSV headers
+awk -v h="$header" 'NR>1 && $0~h {next} {print}' "$outfile" > "$tmp" && mv "$tmp" "$outfile"

--- a/bottom-line/src/main/resources/getmerge-strip-headers-zstd.sh
+++ b/bottom-line/src/main/resources/getmerge-strip-headers-zstd.sh
@@ -14,14 +14,5 @@ aws s3 cp $glob ./tmp_files/ --recursive
 zstd -d --rm ./tmp_files/part-*
 
 # merge files
-cat ./tmp_files/part-* > "$outfile"
+awk '(NR == 1) || (FNR > 1)' ./tmp_files/part-* > "$outfile"
 rm -r tmp_files
-
-# discover the header to skip it later
-header=$(head -n 1 "$outfile")
-
-# where to do temporary file processing
-tmp="$(dirname "$outfile")/tmp.csv"
-
-# run awk to remove extra CSV headers
-awk -v h="$header" 'NR>1 && $0~h {next} {print}' "$outfile" > "$tmp" && mv "$tmp" "$outfile"

--- a/bottom-line/src/main/resources/partitionVariants.py
+++ b/bottom-line/src/main/resources/partitionVariants.py
@@ -73,6 +73,7 @@ if __name__ == '__main__':
     # output the partitioned variants as CSV files for METAL
     df.write \
         .mode('overwrite') \
+        .option("compression", "org.apache.hadoop.io.compress.ZStandardCodec") \
         .partitionBy('dataset', 'ancestry', 'rare') \
         .csv(outdir, sep='\t', header=True)
 

--- a/bottom-line/src/main/resources/runAncestrySpecific.sh
+++ b/bottom-line/src/main/resources/runAncestrySpecific.sh
@@ -14,7 +14,7 @@ OUTDIR="${LOCAL_DIR}/ancestry-specific/${PHENOTYPE}"
 
 # local scripts
 RUN_METAL="/home/hadoop/bin/runMETAL.sh"
-GET_MERGE="/home/hadoop/bin/getmerge-strip-headers.sh"
+GET_MERGE="/home/hadoop/bin/getmerge-strip-headers-zstd.sh"
 
 # start with a clean working directory
 sudo rm -rf "${OUTDIR}"
@@ -44,7 +44,7 @@ for ANCESTRY in "${ANCESTRIES[@]}"; do
 
     # collect all the common variants for each dataset together
     for DATASET in "${DATASETS[@]}"; do
-        GLOB="${SRCDIR}/dataset=${DATASET}/ancestry=${ANCESTRY}/rare=false/part-*"
+        GLOB="${SRCDIR}/dataset=${DATASET}/ancestry=${ANCESTRY}/rare=false/"
 
         # create the destination directory and merge variants there
         sudo mkdir -p "${ANCESTRY_DIR}/${DATASET}"
@@ -57,9 +57,6 @@ for ANCESTRY in "${ANCESTRIES[@]}"; do
     # first run with samplesize (overlap on), then with stderr
     sudo bash "${RUN_METAL}" "SAMPLESIZE" "ON" "${ANALYSIS_DIR}" "${INPUT_FILES[@]}"
     sudo bash "${RUN_METAL}" "STDERR" "OFF" "${ANALYSIS_DIR}" "${INPUT_FILES[@]}"
-
-    # nuke any previously existing staging data
-    sudo aws s3 rm "${S3_PATH}/staging/metaanalysis/ancestry-specific/${PHENOTYPE}/" --recursive
 
     # upload the resuts to S3
     sudo aws s3 cp "${ANALYSIS_DIR}/scheme=SAMPLESIZE/" "${S3_PATH}/staging/ancestry-specific/${PHENOTYPE}/ancestry=${ANCESTRY}/scheme=SAMPLESIZE/" --recursive

--- a/bottom-line/src/main/scala/MetaAnalysisStage.scala
+++ b/bottom-line/src/main/scala/MetaAnalysisStage.scala
@@ -50,12 +50,6 @@ class MetaAnalysisStage(implicit context: Context) extends Stage {
     releaseLabel = ReleaseLabel("emr-6.7.0") // Need emr 6.1+ to read zstd files
   )
 
-  /** Additional resources to upload. */
-  override def additionalResources: Seq[String] = Seq(
-    "runMETAL.sh",
-    "getmerge-strip-headers.sh"
-  )
-
   /** Look for new datasets. */
   override val sources: Seq[Input.Source] = Seq(variants)
 


### PR DESCRIPTION
simple compression, added ability to read compressed data to variant-associations (reads from partition output) and the runAncestrySpecific.sh for MetaAnalysisStage of bottom-line

Compared for a small (2hrCPEP) and large (T2D) phenotype and both came out faster than running on master.

Will compress all data with a temp runner prior to landing the diff. Then after the release will create a management rule to destroy all old uncompressed data in S3.