### PR TITLE
[SBT] remove build properties

### DIFF
--- a/basset/project/build.properties
+++ b/basset/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.0
+sbt.version=1.8.2

--- a/bioindex/project/build.properties
+++ b/bioindex/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.0
+sbt.version=1.8.2

--- a/bottom-line/project/build.properties
+++ b/bottom-line/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.0
+sbt.version=1.8.2

--- a/burden-binning/project/build.properties
+++ b/burden-binning/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.0
+sbt.version=1.8.2

--- a/gene-associations/project/build.properties
+++ b/gene-associations/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.0
+sbt.version=1.8.2

--- a/gregor/project/build.properties
+++ b/gregor/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.0
+sbt.version=1.8.2

--- a/huge/project/build.properties
+++ b/huge/project/build.properties
@@ -1,2 +1,1 @@
-sbt.version=1.7.3
-
+sbt.version=1.8.2

--- a/intake/project/build.properties
+++ b/intake/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.0
+sbt.version=1.8.2

--- a/ldsc/project/build.properties
+++ b/ldsc/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.0
+sbt.version=1.8.2

--- a/magma/project/build.properties
+++ b/magma/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.0
+sbt.version=1.8.2

--- a/vep/project/build.properties
+++ b/vep/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.0
+sbt.version=1.8.2


### PR DESCRIPTION
I'm not sure why this happens since the files are in .gitignore (but maybe it was put into source control long ago and never removed?). Anyways, I accidentally upgrades myself and then dig-aggregator, so this will make it slightly less confusing when someone else comes along. Anyone who runs the aggregator should automatically get upgraded.