### PR TITLE
[LDSC] Remove subregion for partition, partition all the way to dataset

### DIFF
--- a/ldsc/src/main/resources/partitionRegions.py
+++ b/ldsc/src/main/resources/partitionRegions.py
@@ -65,16 +65,15 @@ def main():
 
     opts = argparse.ArgumentParser()
     opts.add_argument('dataset')
-    opts.add_argument('sub_region')
 
     # extract the dataset from the command line
     args = opts.parse_args()
 
-    partitions = args.sub_region.split('-') if args.sub_region != "default" else []
+    partitions = ['annotation', 'tissue', 'biosample', 'dataset']
 
     # get the source and output directories
     srcdir = f'{S3DIR}/annotated_regions/cis-regulatory_elements/{args.dataset}/part-*'
-    outdir = f'{S3DIR}/out/ldsc/regions/{args.sub_region}/partitioned/{args.dataset}'
+    outdir = f'{S3DIR}/out/ldsc/regions/partitioned/{args.dataset}'
 
     # create a spark session
     spark = SparkSession.builder.appName('ldsc').getOrCreate()
@@ -95,12 +94,11 @@ def main():
     df = df.filter(df.annotation.isNotNull())
 
     # fill empty partitions
-    df = df.fillna({'tissue': 'no_tissue'})
     for partition in partitions:
         df = df.fillna({partition: f'no_{partition}'})
 
     # fix any whitespace issues
-    partition_strs = [regexp_replace(df.annotation, ' ', '_'), regexp_replace(df.tissue, ' ', '_')]
+    partition_strs = []
     for partition in partitions:
         partition_strs.append(regexp_replace(df[partition], ' ', '_'))
     # build the partition name
@@ -122,8 +120,9 @@ def main():
         df.dataset
     )
 
-    # output the regions partitioned for LDSC in BED format
-    df.write \
+    df.orderBy(['chromosome', 'start', 'end']) \
+        .coalesce(1) \
+        .write \
         .mode('overwrite') \
         .partitionBy('partition') \
         .csv(outdir, sep='\t', header=False)

--- a/ldsc/src/main/scala/PartitionRegionsStage.scala
+++ b/ldsc/src/main/scala/PartitionRegionsStage.scala
@@ -4,8 +4,6 @@ import org.broadinstitute.dig.aggregator.core._
 import org.broadinstitute.dig.aws.emr._
 
 class PartitionRegionsStage(implicit context: Context) extends Stage {
-  val partitions: Seq[String] = Seq()
-  val subRegion: String = if (partitions.isEmpty) "default" else partitions.mkString("-")
   val cisReg: Input.Source = Input.Source.Dataset("annotated_regions/cis-regulatory_elements/*/")
 
   /** Source inputs. */
@@ -30,6 +28,6 @@ class PartitionRegionsStage(implicit context: Context) extends Stage {
     val script  = resourceUri("partitionRegions.py")
     val dataset = output
 
-    new Job(Job.PySpark(script, dataset, subRegion))
+    new Job(Job.PySpark(script, dataset))
   }
 }


### PR DESCRIPTION
Previously I was using a argvar to determine what to save. This changes the partition to always partition all the way down, and then later for merging it'll decide how much to merge instead of duplicating all the data a bunch.