### PR TITLE
[LDSC] Combine annot/LD across biosamples

### DIFF
--- a/ldsc/src/main/resources/combineLD.py
+++ b/ldsc/src/main/resources/combineLD.py
@@ -1,0 +1,144 @@
+#!/usr/bin/python3
+import argparse
+import gzip
+import os
+import shutil
+import subprocess
+
+s3_in = 's3://dig-analysis-data/out/ldsc/regions/ld_score'
+s3_out = 's3://dig-analysis-data/out/ldsc/regions/combined_ld'
+
+
+def download_files(ancestry, annotation, tissue):
+    subprocess.check_call(['aws', 's3', 'cp',
+                           f'{s3_in}/ancestry={ancestry}/annotation/{annotation}/',
+                           f'ld_files/annotation/{annotation}/', '--recursive'])
+    subprocess.check_call(['aws', 's3', 'cp',
+                           f'{s3_in}/ancestry={ancestry}/annotation-tissue/{annotation}___{tissue}/',
+                           f'ld_files/annotation-tissue/{annotation}___{tissue}/', '--recursive'])
+    biosamples = []
+    s3_ls = subprocess.check_output(['aws', 's3', 'ls', f'{s3_in}/ancestry={ancestry}/annotation-tissue-biosample/']).decode()
+    for line in s3_ls.strip().split('\n'):
+        s3_folder = line.split(' ')[-1].split('/')[0]
+        s3_annotation, s3_tissue, s3_biosample = s3_folder.split('___')
+        if s3_annotation == annotation and s3_tissue == tissue:
+            subprocess.check_call(['aws', 's3', 'cp',
+                                   f'{s3_in}/ancestry={ancestry}/annotation-tissue-biosample/{s3_folder}/',
+                                   f'ld_files/annotation-tissue-biosample/{s3_folder}/', '--recursive'])
+            biosamples.append(s3_biosample)
+    return biosamples
+
+
+def biosample_to_file(annotation, tissue, biosample):
+    return f'ld_files/annotation-tissue-biosample/{annotation}___{tissue}___{biosample}/{annotation}___{tissue}___{biosample}'
+
+
+def tissue_to_file(annotation, tissue):
+    return f'ld_files/annotation-tissue/{annotation}___{tissue}/{annotation}___{tissue}'
+
+
+def annotation_file(annotation):
+    return f'ld_files/annotation/{annotation}/{annotation}'
+
+
+def get_biosample_files(annotation, tissue, biosamples):
+    return [annotation_file(annotation)] + \
+           [biosample_to_file(annotation, tissue, biosample) for biosample in biosamples]
+
+
+def get_tissue_files(annotation, tissue):
+    return [annotation_file(annotation), tissue_to_file(annotation, tissue)]
+
+
+def combine_annot(files, header, sub_region, annotation, tissue, CHR):
+    extension = 'annot.gz'
+    print(extension, CHR)
+    open_files = [gzip.open(f'{f}.{CHR}.{extension}', 'r') for f in files]
+    with gzip.open(f'ld_files/combined/{sub_region}/{annotation}.{tissue}.{CHR}.' + extension, 'w') as f_out:
+        f_out.write(b'\t'.join(header) + b'\n')
+        _ = [f.readline().strip() for f in open_files]  # unused header
+        lines = [f.readline().strip() for f in open_files]
+        while all([len(line) > 0 for line in lines]):
+            f_out.write(b'\t'.join(lines) + b'\n')
+            lines = [f.readline().strip() for f in open_files]
+
+
+def combine_ldscore(files, header, sub_region, annotation, tissue, CHR):
+    extension = 'l2.ldscore.gz'
+    print(extension, CHR)
+    open_files = [gzip.open(f'{f}.{CHR}.{extension}', 'r') for f in files]
+    with gzip.open(f'ld_files/combined/{sub_region}/{annotation}.{tissue}.{CHR}.' + extension, 'w') as f_out:
+        f_out.write(b'\t'.join([b'CHR', b'SNP', b'BP'] + header) + b'\n')
+        _ = [f.readline().strip() for f in open_files]  # unused header
+        lines = open_files[0].readline().strip().split(b'\t') + \
+                [f.readline().strip().split(b'\t')[-1] for f in open_files[1:]]
+        while all([len(line) > 0 for line in lines]):
+            f_out.write(b'\t'.join(lines) + b'\n')
+            lines = open_files[0].readline().strip().split(b'\t') + \
+                    [f.readline().strip().split(b'\t')[-1] for f in open_files[1:]]
+
+
+def combine_non_gzip(files, sub_region, annotation, tissue, CHR, extension):
+    print(extension, CHR)
+    open_files = [open(f'{f}.{CHR}.{extension}', 'r') for f in files]
+    with open(f'ld_files/combined/{sub_region}/{annotation}.{tissue}.{CHR}.' + extension, 'w') as f_out:
+        f_out.write('\t'.join([f.readline().strip() for f in open_files]) + '\n')
+
+
+def combine_sub_region(files, header, sub_region, annotation, tissue):
+    for CHR in range(1, 23):
+        combine_annot(files, header, sub_region, annotation, tissue, CHR)
+        combine_ldscore(files, header, sub_region, annotation, tissue, CHR)
+        combine_non_gzip(files, sub_region, annotation, tissue, CHR, 'l2.M')
+        combine_non_gzip(files, sub_region, annotation, tissue, CHR, 'l2.M_5_50')
+
+
+def combine_biosamples(annotation, tissue, biosamples):
+    header = [annotation.encode()] + [biosample.encode() for biosample in biosamples]
+    files = get_biosample_files(annotation, tissue, biosamples)
+    sub_region = 'annotation-tissue-biosample'
+    combine_sub_region(files, header, sub_region, annotation, tissue)
+
+
+def combine_tissue(annotation, tissue):
+    header = [annotation.encode(), tissue.encode()]
+    files = get_tissue_files(annotation, tissue)
+    sub_region = 'annotation-tissue'
+    combine_sub_region(files, header, sub_region, annotation, tissue)
+
+
+def upload_and_remove(ancestry, annotation, tissue):
+    subprocess.check_call(['touch', 'ld_files/combined/annotation-tissue/_SUCCESS'])
+    subprocess.check_call(['aws', 's3', 'cp',
+                           'ld_files/combined/annotation-tissue/',
+                           f'{s3_out}/ancestry={ancestry}/annotation-tissue/{annotation}___{tissue}/', '--recursive'])
+    subprocess.check_call(['touch', 'ld_files/combined/annotation-tissue-biosample/_SUCCESS'])
+    subprocess.check_call(['aws', 's3', 'cp',
+                           'ld_files/combined/annotation-tissue-biosample/',
+                           f'{s3_out}/ancestry={ancestry}/annotation-tissue-biosample/{annotation}___{tissue}/', '--recursive'])
+    shutil.rmtree('ld_files')
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--ancestry', required=True, type=str,
+                        help="Ancestry (g1000 style e.g. EUR)")
+    parser.add_argument('--annotation', required=True, type=str,
+                        help="Sub region name (e.g. accessible-chromatin)")
+    parser.add_argument('--tissue', required=True, type=str,
+                        help="A tissue to combine (e.g. pancreas)")
+    args = parser.parse_args()
+    ancestry = args.ancestry
+    annotation = args.annotation
+    tissue = args.tissue
+    biosamples = download_files(ancestry, annotation, tissue)
+    os.mkdir('ld_files/combined')
+    os.mkdir('ld_files/combined/annotation-tissue')
+    os.mkdir('ld_files/combined/annotation-tissue-biosample')
+    combine_biosamples(annotation, tissue, biosamples)
+    combine_tissue(annotation, tissue)
+    upload_and_remove(ancestry, annotation, tissue)
+
+
+if __name__ == '__main__':
+    main()

--- a/ldsc/src/main/scala/CombineLDStage.scala
+++ b/ldsc/src/main/scala/CombineLDStage.scala
@@ -1,0 +1,68 @@
+package org.broadinstitute.dig.aggregator.methods.ldsc
+
+import org.broadinstitute.dig.aggregator.core._
+import org.broadinstitute.dig.aws._
+import org.broadinstitute.dig.aws.emr._
+import org.broadinstitute.dig.aws.Ec2.Strategy
+
+class CombineLDStage(implicit context: Context) extends Stage {
+
+  val ldFiles: Input.Source = Input.Source.Success(s"out/ldsc/regions/ld_score/*/*/*/")
+
+  /** Source inputs. */
+  override val sources: Seq[Input.Source] = Seq(ldFiles)
+
+  /** Just need a single machine with no applications, but a good drive. */
+  override def cluster: ClusterDef = super.cluster.copy(
+    instances = 1,
+    applications = Seq.empty,
+    releaseLabel = ReleaseLabel("emr-6.7.0"),
+    stepConcurrency = 5
+  )
+
+  override val rules: PartialFunction[Input, Outputs] = {
+    case ldFiles(ancestry, subRegion, region) if subRegion == "annotation-tissue" =>
+      Outputs.Named(CombineLDTissue(ancestry.split("=").last, region).toOutput)
+    case ldFiles(ancestry, subRegion, region) if subRegion == "annotation-tissue-biosample" =>
+      Outputs.Named(CombineLDBiosample(ancestry.split("=").last, region).toOutput)
+    case _ => Outputs.Null
+  }
+
+  override def make(output: String): Job = {
+    val combineLD = CombineLD.fromOutput(output)
+    new Job(Job.Script(
+      resourceUri("combineLD.py"),
+      s"--ancestry=${combineLD.ancestry}",
+      s"--annotation=${combineLD.annotation}",
+      s"--tissue=${combineLD.tissue}"
+    ))
+  }
+}
+
+case class CombineLDTissue(
+  ancestry: String,
+  region: String
+) {
+  val Seq(annotation, tissue) = region.split("___").toSeq
+  val toOutput: String = s"$ancestry/$annotation/$tissue"
+}
+
+case class CombineLDBiosample(
+  ancestry: String,
+  region: String
+) {
+  val Seq(annotation, tissue, _) = region.split("___").toSeq
+  val toOutput: String = s"$ancestry/$annotation/$tissue"
+}
+
+case class CombineLD(
+  ancestry: String,
+  annotation: String,
+  tissue: String
+)
+
+object CombineLD {
+  def fromOutput(output: String): CombineLD = output.split("/").toSeq match {
+    case Seq(ancestry, annotation, tissue) => CombineLD(ancestry, annotation, tissue)
+  }
+}

--- a/ldsc/src/main/scala/LDScoreRegression.scala
+++ b/ldsc/src/main/scala/LDScoreRegression.scala
@@ -26,6 +26,7 @@ object LDScoreRegression extends Method {
     addStage(new MergeRegionsStage)
     addStage(new RegionToAnnotStage)
     addStage(new AnnotToLDStage)
+    addStage(new CombineLDStage)
     addStage(new MakeSumstatsStage)
     addStage(new PartitionedHeritabilityStage)
     addStage(new TranslatePartitionedHeritabilityStage)


### PR DESCRIPTION
This is for the new method Jason, Kyle, and I have been working on. It combines the LD, annot, etc. files together such that for biosamples it runs annotation, <all biosamples> together as confounders, and for tissue it runs, <annotation>,<tissue> such that annotation is also a confounder there.