### PR TITLE
[Bottom Line] Split out bottom-line analyses into separate area

### DIFF
--- a/bioindex/src/main/resources/associations.py
+++ b/bioindex/src/main/resources/associations.py
@@ -22,10 +22,10 @@ def main():
 
     # load the trans-ethnic, meta-analysis, top variants and write them sorted
     if args.ancestry == 'Mixed':
-        srcdir = f's3://dig-analysis-data/out/metaanalysis/trans-ethnic/{args.phenotype}/part-*'
+        srcdir = f's3://dig-analysis-data/out/metaanalysis/bottom-line/trans-ethnic/{args.phenotype}/part-*'
         outdir = f's3://{s3_bucket}/associations/phenotype/trans-ethnic/{args.phenotype}'
     else:
-        srcdir = f's3://dig-analysis-data/out/metaanalysis/ancestry-specific/{args.phenotype}/ancestry={args.ancestry}/part-*'
+        srcdir = f's3://dig-analysis-data/out/metaanalysis/bottom-line/ancestry-specific/{args.phenotype}/ancestry={args.ancestry}/part-*'
         outdir = f's3://{s3_bucket}/ancestry-associations/phenotype/{args.phenotype}/{args.ancestry}'
 
     df = spark.read.json(srcdir) \

--- a/bioindex/src/main/resources/clumpedAssociationsMatrix.py
+++ b/bioindex/src/main/resources/clumpedAssociationsMatrix.py
@@ -35,12 +35,12 @@ def main():
     # source and output locations
     s3_bucket = 'dig-bio-index'
     if args.ancestry == 'Mixed':
-        clumpdir = f's3://dig-analysis-data/out/metaanalysis/clumped/*/part-*'
-        assocsdir = f's3://dig-analysis-data/out/metaanalysis/trans-ethnic/*/part-*'
+        clumpdir = f's3://dig-analysis-data/out/metaanalysis/bottom-line/clumped/*/part-*'
+        assocsdir = f's3://dig-analysis-data/out/metaanalysis/bottom-line/trans-ethnic/*/part-*'
         outdir = f's3://{s3_bucket}/associations/matrix'
     else:
-        clumpdir = f's3://dig-analysis-data/out/metaanalysis/ancestry-clumped/*/ancestry={args.ancestry}/part-*'
-        assocsdir = f's3://dig-analysis-data/out/metaanalysis/ancestry-specific/*/ancestry={args.ancestry}/part-*'
+        clumpdir = f's3://dig-analysis-data/out/metaanalysis/bottom-line/ancestry-clumped/*/ancestry={args.ancestry}/part-*'
+        assocsdir = f's3://dig-analysis-data/out/metaanalysis/bottom-line/ancestry-specific/*/ancestry={args.ancestry}/part-*'
         outdir = f's3://{s3_bucket}/ancestry-associations/matrix/{args.ancestry}'
 
     clumps = get_clump_df(spark, clumpdir) \

--- a/bioindex/src/main/resources/clumpedVariants.py
+++ b/bioindex/src/main/resources/clumpedVariants.py
@@ -17,10 +17,10 @@ def main():
     # source and output locations
     s3_bucket = 'dig-bio-index'
     if args.ancestry == 'Mixed':
-        srcdir = f's3://dig-analysis-data/out/metaanalysis/clumped/*/part-*'
+        srcdir = f's3://dig-analysis-data/out/metaanalysis/bottom-line/clumped/*/part-*'
         outdir = f's3://{s3_bucket}/associations/clump'
     else:
-        srcdir = f's3://dig-analysis-data/out/metaanalysis/ancestry-clumped/*/ancestry={args.ancestry}/part-*'
+        srcdir = f's3://dig-analysis-data/out/metaanalysis/bottom-line/ancestry-clumped/*/ancestry={args.ancestry}/part-*'
         outdir = f's3://{s3_bucket}/ancestry-associations/clump/{args.ancestry}'
 
     clumps = spark.read.json(srcdir)\

--- a/bioindex/src/main/resources/phewasAssociations.py
+++ b/bioindex/src/main/resources/phewasAssociations.py
@@ -45,12 +45,12 @@ def main():
     # source and output locations
     s3_bucket = 'dig-bio-index'
     if args.ancestry == 'Mixed':
-        srcdir = f's3://dig-analysis-data/out/metaanalysis/trans-ethnic/*/part-*'
-        clumpdir = f's3://dig-analysis-data/out/metaanalysis/clumped/*/part-*'
+        srcdir = f's3://dig-analysis-data/out/metaanalysis/bottom-line/trans-ethnic/*/part-*'
+        clumpdir = f's3://dig-analysis-data/out/metaanalysis/bottom-line/clumped/*/part-*'
         outdir = f's3://{s3_bucket}/associations/phewas'
     else:
-        srcdir = f's3://dig-analysis-data/out/metaanalysis/ancestry-specific/*/ancestry={args.ancestry}/part-*'
-        clumpdir = f's3://dig-analysis-data/out/metaanalysis/ancestry-clumped/*/ancestry={args.ancestry}/part-*'
+        srcdir = f's3://dig-analysis-data/out/metaanalysis/bottom-line/ancestry-specific/*/ancestry={args.ancestry}/part-*'
+        clumpdir = f's3://dig-analysis-data/out/metaanalysis/bottom-line/ancestry-clumped/*/ancestry={args.ancestry}/part-*'
         outdir = f's3://{s3_bucket}/ancestry-associations/phewas/{args.ancestry}'
 
     df = get_src_df(spark, srcdir) \

--- a/bioindex/src/main/resources/plotAssociations.py
+++ b/bioindex/src/main/resources/plotAssociations.py
@@ -81,10 +81,10 @@ def get_input_output(args):
         return f's3://dig-analysis-data/variants/{args.dataset}',\
                f's3://{s3_bucket}/plot/dataset/{args.dataset}'
     elif args.ancestry == 'Mixed':
-        return f's3://dig-analysis-data/out/metaanalysis/trans-ethnic/{args.phenotype}',\
+        return f's3://dig-analysis-data/out/metaanalysis/bottom-line/trans-ethnic/{args.phenotype}',\
                f's3://{s3_bucket}/plot/phenotype/{args.phenotype}'
     else:
-        return f's3://dig-analysis-data/out/metaanalysis/ancestry-specific/{args.phenotype}/ancestry={args.ancestry}', \
+        return f's3://dig-analysis-data/out/metaanalysis/bottom-line/ancestry-specific/{args.phenotype}/ancestry={args.ancestry}', \
                f's3://{s3_bucket}/plot/phenotype/{args.phenotype}/{args.ancestry}'
 
 

--- a/bioindex/src/main/resources/topAssociations.py
+++ b/bioindex/src/main/resources/topAssociations.py
@@ -17,10 +17,10 @@ def main():
     # source and output locations
     s3_bucket = 'dig-bio-index'
     if args.ancestry == 'Mixed':
-        srcdir = f's3://dig-analysis-data/out/metaanalysis/clumped/*/part-*'
+        srcdir = f's3://dig-analysis-data/out/metaanalysis/bottom-line/clumped/*/part-*'
         outdir = f's3://{s3_bucket}/associations/{{}}'
     else:
-        srcdir = f's3://dig-analysis-data/out/metaanalysis/ancestry-clumped/*/ancestry={args.ancestry}/part-*'
+        srcdir = f's3://dig-analysis-data/out/metaanalysis/bottom-line/ancestry-clumped/*/ancestry={args.ancestry}/part-*'
         outdir = f's3://{s3_bucket}/ancestry-associations/{{}}/{args.ancestry}'
 
     df = spark.read.json(srcdir) \

--- a/bioindex/src/main/scala/AssociationsStage.scala
+++ b/bioindex/src/main/scala/AssociationsStage.scala
@@ -10,8 +10,8 @@ import org.broadinstitute.dig.aws.emr._
 class AssociationsStage(implicit context: Context) extends Stage {
   import MemorySize.Implicits._
 
-  val transEthnic = Input.Source.Success("out/metaanalysis/trans-ethnic/*/")
-  val ancestrySpecific = Input.Source.Success("out/metaanalysis/ancestry-specific/*/*/")
+  val transEthnic = Input.Source.Success("out/metaanalysis/bottom-line/trans-ethnic/*/")
+  val ancestrySpecific = Input.Source.Success("out/metaanalysis/bottom-line/ancestry-specific/*/*/")
 
   /** Input sources. */
   override val sources: Seq[Input.Source] = Seq(transEthnic, ancestrySpecific)

--- a/bioindex/src/main/scala/ClumpedVariantsStage.scala
+++ b/bioindex/src/main/scala/ClumpedVariantsStage.scala
@@ -10,8 +10,8 @@ import org.broadinstitute.dig.aws.emr._
 class ClumpedVariantsStage(implicit context: Context) extends Stage {
   import MemorySize.Implicits._
 
-  val clumped: Input.Source = Input.Source.Success("out/metaanalysis/clumped/*/")
-  val ancestryClumped: Input.Source = Input.Source.Success("out/metaanalysis/ancestry-clumped/*/*/")
+  val clumped: Input.Source = Input.Source.Success("out/metaanalysis/bottom-line/clumped/*/")
+  val ancestryClumped: Input.Source = Input.Source.Success("out/metaanalysis/bottom-line/ancestry-clumped/*/*/")
 
   /** Input sources. */
   override val sources: Seq[Input.Source] = Seq(clumped, ancestryClumped)

--- a/bioindex/src/main/scala/PhewasAssociationsStage.scala
+++ b/bioindex/src/main/scala/PhewasAssociationsStage.scala
@@ -10,10 +10,10 @@ import org.broadinstitute.dig.aws.emr._
 class PhewasAssociationsStage(implicit context: Context) extends Stage {
   import MemorySize.Implicits._
 
-  val transEthnic: Input.Source = Input.Source.Success("out/metaanalysis/trans-ethnic/*/")
-  val ancestrySpecific: Input.Source = Input.Source.Success("out/metaanalysis/ancestry-specific/*/*/")
-  val clumped: Input.Source = Input.Source.Success("out/metaanalysis/clumped/*/")
-  val ancestryClumped: Input.Source = Input.Source.Success("out/metaanalysis/ancestry-clumped/*/*/")
+  val transEthnic: Input.Source = Input.Source.Success("out/metaanalysis/bottom-line/trans-ethnic/*/")
+  val ancestrySpecific: Input.Source = Input.Source.Success("out/metaanalysis/bottom-line/ancestry-specific/*/*/")
+  val clumped: Input.Source = Input.Source.Success("out/metaanalysis/bottom-line/clumped/*/")
+  val ancestryClumped: Input.Source = Input.Source.Success("out/metaanalysis/bottom-line/ancestry-clumped/*/*/")
 
   /** Input sources. */
   override val sources: Seq[Input.Source] = Seq(transEthnic, ancestrySpecific, clumped, ancestryClumped)

--- a/bioindex/src/main/scala/TopAssociationsStage.scala
+++ b/bioindex/src/main/scala/TopAssociationsStage.scala
@@ -8,8 +8,8 @@ import org.broadinstitute.dig.aws.emr._
   * outputs are to the dig-bio-index bucket in S3.
   */
 class TopAssociationsStage(implicit context: Context) extends Stage {
-  val clumped: Input.Source = Input.Source.Success("out/metaanalysis/clumped/")
-  val ancestryClumped: Input.Source = Input.Source.Success("out/metaanalysis/ancestry-clumped/*/*/")
+  val clumped: Input.Source = Input.Source.Success("out/metaanalysis/bottom-line/clumped/")
+  val ancestryClumped: Input.Source = Input.Source.Success("out/metaanalysis/bottom-line/ancestry-clumped/*/*/")
 
   /** Input sources. */
   override val sources: Seq[Input.Source] = Seq(clumped, ancestryClumped)

--- a/bottom-line/src/main/resources/clumpedAssociations.py
+++ b/bottom-line/src/main/resources/clumpedAssociations.py
@@ -22,14 +22,14 @@ def main():
 
     # source data and output location
     if args.ancestry == 'Mixed':
-        srcdir = f'{S3_BUCKET}/out/metaanalysis/trans-ethnic/{args.phenotype}/part-*'
-        clumpdir = f'{S3_BUCKET}/out/metaanalysis/staging/clumped/{args.phenotype}/*.json'
-        outdir = f'{S3_BUCKET}/out/metaanalysis/clumped/{args.phenotype}'
+        srcdir = f'{S3_BUCKET}/out/metaanalysis/bottom-line/trans-ethnic/{args.phenotype}/part-*'
+        clumpdir = f'{S3_BUCKET}/out/metaanalysis/bottom-line/staging/clumped/{args.phenotype}/*.json'
+        outdir = f'{S3_BUCKET}/out/metaanalysis/bottom-line/clumped/{args.phenotype}'
     else:
         ancestry_path = f'{args.phenotype}/ancestry={args.ancestry}'
-        srcdir = f'{S3_BUCKET}/out/metaanalysis/ancestry-specific/{ancestry_path}/part-*'
-        clumpdir = f'{S3_BUCKET}/out/metaanalysis/staging/ancestry-clumped/{ancestry_path}/*.json'
-        outdir = f'{S3_BUCKET}/out/metaanalysis/ancestry-clumped/{ancestry_path}'
+        srcdir = f'{S3_BUCKET}/out/metaanalysis/bottom-line/ancestry-specific/{ancestry_path}/part-*'
+        clumpdir = f'{S3_BUCKET}/out/metaanalysis/bottom-line/staging/ancestry-clumped/{ancestry_path}/*.json'
+        outdir = f'{S3_BUCKET}/out/metaanalysis/bottom-line/ancestry-clumped/{ancestry_path}'
 
     # initialize spark session
     spark = SparkSession.builder.appName('bottom-line').getOrCreate()

--- a/bottom-line/src/main/resources/loadAnalysis.py
+++ b/bottom-line/src/main/resources/loadAnalysis.py
@@ -14,7 +14,8 @@ from pyspark.sql.functions import col, isnan, lit, when  # pylint: disable=E0611
 # where in S3 meta-analysis data is
 s3_bucket = 's3://dig-analysis-data'
 s3_path = f'{s3_bucket}/out/metaanalysis'
-s3_staging = f'{s3_path}/staging'
+s3_bottom_line = f'{s3_path}/bottom-line'
+s3_staging = f'{s3_bottom_line}/staging'
 
 # this is the schema written out by the variant partition process
 variants_schema = StructType(
@@ -188,7 +189,7 @@ def load_ancestry_specific_analysis(phenotype, ancestry):
     Load the METAL results for each ancestry into a single DataFrame.
     """
     srcdir = f'{s3_staging}/ancestry-specific/{phenotype}/ancestry={ancestry}'
-    outdir = f'{s3_path}/ancestry-specific/{phenotype}/ancestry={ancestry}'
+    outdir = f'{s3_bottom_line}/ancestry-specific/{phenotype}/ancestry={ancestry}'
 
     print(f'Loading ancestry {ancestry}...')
 
@@ -242,7 +243,7 @@ def load_trans_ethnic_analysis(phenotype):
     HDFS (S3) where they can be kept and uploaded to a database.
     """
     srcdir = f'{s3_staging}/trans-ethnic/{phenotype}'
-    outdir = f'{s3_path}/trans-ethnic/{phenotype}'
+    outdir = f'{s3_bottom_line}/trans-ethnic/{phenotype}'
 
     print("Loading from {} to {}".format(srcdir, outdir))
 

--- a/bottom-line/src/main/resources/runAncestrySpecific.sh
+++ b/bottom-line/src/main/resources/runAncestrySpecific.sh
@@ -55,10 +55,10 @@ sudo zstd --rm "${ANALYSIS_DIR}/scheme=SAMPLESIZE/METAANALYSIS1.tbl"
 sudo zstd --rm "${ANALYSIS_DIR}/scheme=STDERR/METAANALYSIS1.tbl"
 
 # upload the resuts to S3
-sudo aws s3 cp "${ANALYSIS_DIR}/scheme=SAMPLESIZE/" "${S3_PATH}/staging/ancestry-specific/${PHENOTYPE}/ancestry=${ANCESTRY}/scheme=SAMPLESIZE/" --recursive
-sudo aws s3 cp "${ANALYSIS_DIR}/scheme=STDERR/" "${S3_PATH}/staging/ancestry-specific/${PHENOTYPE}/ancestry=${ANCESTRY}/scheme=STDERR/" --recursive
+sudo aws s3 cp "${ANALYSIS_DIR}/scheme=SAMPLESIZE/" "${S3_PATH}/bottom-line/staging/ancestry-specific/${PHENOTYPE}/ancestry=${ANCESTRY}/scheme=SAMPLESIZE/" --recursive
+sudo aws s3 cp "${ANALYSIS_DIR}/scheme=STDERR/" "${S3_PATH}/bottom-line/staging/ancestry-specific/${PHENOTYPE}/ancestry=${ANCESTRY}/scheme=STDERR/" --recursive
 sudo touch "${ANALYSIS_DIR}/_SUCCESS"
-sudo aws s3 cp "${ANALYSIS_DIR}/_SUCCESS" "${S3_PATH}/staging/ancestry-specific/${PHENOTYPE}/ancestry=${ANCESTRY}/"
+sudo aws s3 cp "${ANALYSIS_DIR}/_SUCCESS" "${S3_PATH}/bottom-line/staging/ancestry-specific/${PHENOTYPE}/ancestry=${ANCESTRY}/"
 
 # remove the analysis directory
 sudo rm -rf "${OUTDIR}"

--- a/bottom-line/src/main/resources/runPlink.py
+++ b/bottom-line/src/main/resources/runPlink.py
@@ -284,16 +284,16 @@ def concat_rare(clumped, rare):
 
 
 def get_trans_ethnic_paths(args):
-    srcdir = f'{S3DIR}/out/metaanalysis/trans-ethnic/{args.phenotype}'
-    plinkdir = f'{S3DIR}/out/metaanalysis/staging/plink/{args.phenotype}'
-    outdir = f'{S3DIR}/out/metaanalysis/staging/clumped/{args.phenotype}'
+    srcdir = f'{S3DIR}/out/metaanalysis/bottom-line/trans-ethnic/{args.phenotype}'
+    plinkdir = f'{S3DIR}/out/metaanalysis/bottom-line/staging/plink/{args.phenotype}'
+    outdir = f'{S3DIR}/out/metaanalysis/bottom-line/staging/clumped/{args.phenotype}'
     return srcdir, plinkdir, outdir
 
 
 def get_ancestry_specific_paths(args):
-    srcdir = f'{S3DIR}/out/metaanalysis/ancestry-specific/{args.phenotype}/ancestry={args.ancestry}'
-    plinkdir = f'{S3DIR}/out/metaanalysis/staging/ancestry-plink/{args.phenotype}'
-    outdir = f'{S3DIR}/out/metaanalysis/staging/ancestry-clumped/{args.phenotype}/ancestry={args.ancestry}'
+    srcdir = f'{S3DIR}/out/metaanalysis/bottom-line/ancestry-specific/{args.phenotype}/ancestry={args.ancestry}'
+    plinkdir = f'{S3DIR}/out/metaanalysis/bottom-line/staging/ancestry-plink/{args.phenotype}'
+    outdir = f'{S3DIR}/out/metaanalysis/bottom-line/staging/ancestry-clumped/{args.phenotype}/ancestry={args.ancestry}'
     return srcdir, plinkdir, outdir
 
 

--- a/bottom-line/src/main/resources/runTransEthnic.sh
+++ b/bottom-line/src/main/resources/runTransEthnic.sh
@@ -9,7 +9,7 @@ S3_PATH="s3://dig-analysis-data/out/metaanalysis"
 LOCAL_DIR="/mnt/var/metal"
 
 # read and output directories
-SRCDIR="${S3_PATH}/ancestry-specific/${PHENOTYPE}"
+SRCDIR="${S3_PATH}/bottom-line/ancestry-specific/${PHENOTYPE}"
 OUTDIR="${LOCAL_DIR}/trans-ethnic/${PHENOTYPE}"
 
 # local scripts
@@ -72,9 +72,9 @@ sudo zstd --rm "${ANALYSIS_DIR}/scheme=SAMPLESIZE/METAANALYSIS1.tbl"
 sudo zstd --rm "${ANALYSIS_DIR}/scheme=STDERR/METAANALYSIS1.tbl"
 
 # upload the resuts to S3
-sudo aws s3 cp "${ANALYSIS_DIR}/scheme=SAMPLESIZE/" "${S3_PATH}/staging/trans-ethnic/${PHENOTYPE}/scheme=SAMPLESIZE/" --recursive
-sudo aws s3 cp "${ANALYSIS_DIR}/scheme=STDERR/" "${S3_PATH}/staging/trans-ethnic/${PHENOTYPE}/scheme=STDERR/" --recursive
+sudo aws s3 cp "${ANALYSIS_DIR}/scheme=SAMPLESIZE/" "${S3_PATH}/bottom-line/staging/trans-ethnic/${PHENOTYPE}/scheme=SAMPLESIZE/" --recursive
+sudo aws s3 cp "${ANALYSIS_DIR}/scheme=STDERR/" "${S3_PATH}/bottom-line/staging/trans-ethnic/${PHENOTYPE}/scheme=STDERR/" --recursive
 sudo touch "${ANALYSIS_DIR}/_SUCCESS"
-sudo aws s3 cp "${ANALYSIS_DIR}/_SUCCESS" "${S3_PATH}/staging/trans-ethnic/${PHENOTYPE}/"
+sudo aws s3 cp "${ANALYSIS_DIR}/_SUCCESS" "${S3_PATH}/bottom-line/staging/trans-ethnic/${PHENOTYPE}/"
 
 sudo rm -rf "${OUTDIR}"

--- a/bottom-line/src/main/scala/ClumpedAssociationsStage.scala
+++ b/bottom-line/src/main/scala/ClumpedAssociationsStage.scala
@@ -11,8 +11,8 @@ import org.broadinstitute.dig.aws.Ec2.Strategy
 class ClumpedAssociationsStage(implicit context: Context) extends Stage {
   import MemorySize.Implicits._
 
-  val transEthnic = Input.Source.Success("out/metaanalysis/trans-ethnic/*/")
-  val ancestrySpecific = Input.Source.Success("out/metaanalysis/ancestry-specific/*/*/")
+  val transEthnic = Input.Source.Success("out/metaanalysis/bottom-line/trans-ethnic/*/")
+  val ancestrySpecific = Input.Source.Success("out/metaanalysis/bottom-line/ancestry-specific/*/*/")
   val snps: Input.Source       = Input.Source.Success("out/varianteffect/snp/")
 
   /** The output of meta-analysis is the input for top associations. */

--- a/bottom-line/src/main/scala/LoadAncestrySpecificStage.scala
+++ b/bottom-line/src/main/scala/LoadAncestrySpecificStage.scala
@@ -9,7 +9,7 @@ class LoadAncestrySpecificStage(implicit context: Context) extends Stage {
   import MemorySize.Implicits._
   import org.broadinstitute.dig.aggregator.core.Implicits.S3Key
 
-  val ancestrySpecificTables: Input.Source = Input.Source.Success("out/metaanalysis/staging/ancestry-specific/*/*/")
+  val ancestrySpecificTables: Input.Source = Input.Source.Success("out/metaanalysis/bottom-line/staging/ancestry-specific/*/*/")
   val variants: Input.Source = Input.Source.Success("out/metaanalysis/variants/*/*/")
 
   // NOTE: Fairly slow, but this can run with a single m5.2xlarge if necessary

--- a/bottom-line/src/main/scala/LoadTransEthnicStage.scala
+++ b/bottom-line/src/main/scala/LoadTransEthnicStage.scala
@@ -10,7 +10,7 @@ class LoadTransEthnicStage(implicit context: Context) extends Stage {
   import org.broadinstitute.dig.aggregator.core.Implicits.S3Key
 
   val variants: Input.Source = Input.Source.Success("variants/*/*/*/")
-  val transEthnicTables: Input.Source = Input.Source.Success("out/metaanalysis/staging/trans-ethnic/*/")
+  val transEthnicTables: Input.Source = Input.Source.Success("out/metaanalysis/bottom-line/staging/trans-ethnic/*/")
 
   // NOTE: Fairly slow, but this can run with a single m5.2xlarge if necessary
   // A cluster of 3 compute instances though makes it quite swift

--- a/bottom-line/src/main/scala/TransEthnicStage.scala
+++ b/bottom-line/src/main/scala/TransEthnicStage.scala
@@ -7,7 +7,7 @@ import org.broadinstitute.dig.aws.Ec2.Strategy
 
 class TransEthnicStage(implicit context: Context) extends Stage {
 
-  val ancestrySpecific: Input.Source = Input.Source.Success("out/metaanalysis/ancestry-specific/*/")
+  val ancestrySpecific: Input.Source = Input.Source.Success("out/metaanalysis/bottom-line/ancestry-specific/*/")
 
   // NOTE: If jobs report a mem_alloc issue bump the instance memory. For disk space errors increase the volume size
   override val cluster: ClusterDef = super.cluster.copy(

--- a/huge/src/main/scala/HugeCommonStage.scala
+++ b/huge/src/main/scala/HugeCommonStage.scala
@@ -26,7 +26,7 @@ class HugeCommonStage(implicit context: Context) extends Stage {
 
   val genesDir: String                  = "out/huge/geneidmap/genes/"
   val geneAssocFiles: FilesForPhenotype = new FilesForPhenotype("gene_associations/combined/<phenotype>/")
-  val variantFiles: FilesForPhenotype   = new FilesForPhenotype("out/metaanalysis/trans-ethnic/<phenotype>/")
+  val variantFiles: FilesForPhenotype   = new FilesForPhenotype("out/metaanalysis/bottom-line/trans-ethnic/<phenotype>/")
   val cacheDir: String                  = "out/huge/cache/"
   val outDir: FilesForPhenotype         = new FilesForPhenotype("out/huge/common/<phenotype>/")
 

--- a/ldsc/src/main/resources/makeSumstats.py
+++ b/ldsc/src/main/resources/makeSumstats.py
@@ -75,7 +75,7 @@ def get_s3_dir(phenotype, ancestry):
         if tech_dataset is not None:
             return f's3://dig-analysis-data/variants/{tech_dataset}/{phenotype}/'
     else:
-        return f's3://dig-analysis-data/out/metaanalysis/ancestry-specific/{phenotype}/ancestry={ancestry}/'
+        return f's3://dig-analysis-data/out/metaanalysis/bottom-line/ancestry-specific/{phenotype}/ancestry={ancestry}/'
 
 
 def get_single_json_file(s3_dir, phenotype, ancestry):

--- a/ldsc/src/main/resources/mungeStats.sh
+++ b/ldsc/src/main/resources/mungeStats.sh
@@ -5,7 +5,7 @@ S3DIR=$JOB_BUCKET
 PHENOTYPE=$1
 
 # input and output
-SRCDIR="${S3DIR}/out/metaanalysis/staging/trans-ethnic/${PHENOTYPE}"
+SRCDIR="${S3DIR}/out/metaanalysis/bottom-line/staging/trans-ethnic/${PHENOTYPE}"
 OUTDIR="${S3DIR}/out/ldsc/sumstats/${PHENOTYPE}"
 
 # TODO: Remove references to staging data. Use trans-ethnic results instead

--- a/ldsc/src/main/scala/MakeSumstatsStage.scala
+++ b/ldsc/src/main/scala/MakeSumstatsStage.scala
@@ -8,7 +8,7 @@ import org.broadinstitute.dig.aws.MemorySize
 class MakeSumstatsStage(implicit context: Context) extends Stage {
   import MemorySize.Implicits._
 
-  val ancestrySpecific: Input.Source = Input.Source.Success("out/metaanalysis/ancestry-specific/*/*/")
+  val ancestrySpecific: Input.Source = Input.Source.Success("out/metaanalysis/bottom-line/ancestry-specific/*/*/")
   val mixedDatasets: Input.Source = Input.Source.Success("variants/*/*/*/")
 
   /** Source inputs. */

--- a/magma/src/main/resources/variantAssociations.py
+++ b/magma/src/main/resources/variantAssociations.py
@@ -58,7 +58,7 @@ def get_s3_dir(phenotype, ancestry):
         if tech_dataset is not None:
             return f'{s3dir}/variants/{tech_dataset}/{phenotype}/'
     else:
-        return f'{s3dir}/out/metaanalysis/ancestry-specific/{phenotype}/ancestry={ancestry}/'
+        return f'{s3dir}/out/metaanalysis/bottom-line/ancestry-specific/{phenotype}/ancestry={ancestry}/'
 
 
 def main():

--- a/magma/src/main/scala/VariantAssociationsStage.scala
+++ b/magma/src/main/scala/VariantAssociationsStage.scala
@@ -11,7 +11,7 @@ import org.broadinstitute.dig.aws.Ec2.Strategy
 class VariantAssociationsStage(implicit context: Context) extends Stage {
   import MemorySize.Implicits._
 
-  val ancestrySpecific: Input.Source = Input.Source.Success("out/metaanalysis/ancestry-specific/*/*/")
+  val ancestrySpecific: Input.Source = Input.Source.Success("out/metaanalysis/bottom-line/ancestry-specific/*/*/")
   val mixedDatasets: Input.Source = Input.Source.Success("variants/*/*/*/")
   val snps: Input.Source = Input.Source.Success("out/varianteffect/snp/")
 


### PR DESCRIPTION
A little wonky (in the political sense).

Basically we are adding other meta-analyses as part of Furkan's project which is looking promising and should produce data of interest for the portal sooner rather than later. To have it work in the simplest manner though it makes sense to separate the various meta-analyses into their own areas.

This is step one. Once the other meta-analyses are added (steps 2 and 3) I'll probably look to move the clumping out as a downstream analysis as opposed to being in the meta-analysis section (which it isn't).