### PR TITLE
[Clumping] Clump all and add analysis run as well

### DIFF
--- a/bottom-line/src/main/resources/clumpedAssociations.py
+++ b/bottom-line/src/main/resources/clumpedAssociations.py
@@ -1,10 +1,13 @@
 import argparse
-import os
+import subprocess
 
 from pyspark.sql import SparkSession
 from pyspark.sql.functions import col, lit, signum
 
 S3_BUCKET = 's3://dig-analysis-data'
+
+def check_clump_error(clump_path):
+    return subprocess.call(['aws', 's3', 'ls', clump_path, '--recursive'])
 
 
 def main():
@@ -16,52 +19,56 @@ def main():
     opts = argparse.ArgumentParser()
     opts.add_argument('--phenotype', type=str, required=True)
     opts.add_argument('--ancestry', type=str, required=True)
+    opts.add_argument('--meta-type', type=str, required=True)
+    opts.add_argument('--param-type', type=str, required=True)
 
     # parse command line
     args = opts.parse_args()
 
     # source data and output location
-    if args.ancestry == 'Mixed':
-        srcdir = f'{S3_BUCKET}/out/metaanalysis/bottom-line/trans-ethnic/{args.phenotype}/part-*'
-        clumpdir = f'{S3_BUCKET}/out/metaanalysis/bottom-line/staging/clumped/{args.phenotype}/*.json'
-        outdir = f'{S3_BUCKET}/out/metaanalysis/bottom-line/clumped/{args.phenotype}'
+    if args.ancestry == 'TE':
+        srcdir = f'{S3_BUCKET}/out/metaanalysis/{args.meta_type}/trans-ethnic/{args.phenotype}/part-*'
+        clumpdir = f'{S3_BUCKET}/out/metaanalysis/{args.meta_type}/staging/clumped/{args.phenotype}'
+        outdir = f'{S3_BUCKET}/out/metaanalysis/{args.meta_type}/clumped/{args.phenotype}'
     else:
-        ancestry_path = f'{args.phenotype}/ancestry={args.ancestry}'
-        srcdir = f'{S3_BUCKET}/out/metaanalysis/bottom-line/ancestry-specific/{ancestry_path}/part-*'
-        clumpdir = f'{S3_BUCKET}/out/metaanalysis/bottom-line/staging/ancestry-clumped/{ancestry_path}/*.json'
-        outdir = f'{S3_BUCKET}/out/metaanalysis/bottom-line/ancestry-clumped/{ancestry_path}'
+        param_type_suffix = '-analysis' if args.param_type == 'analysis' else ''
+        ancestry_path = f'{param_type_suffix}/{args.phenotype}/ancestry={args.ancestry}'
+        srcdir = f'{S3_BUCKET}/out/metaanalysis/{args.meta_type}/ancestry-specific/{args.phenotype}/ancestry={args.ancestry}/part-*'
+        clumpdir = f'{S3_BUCKET}/out/metaanalysis/{args.meta_type}/staging/ancestry-clumped{ancestry_path}'
+        outdir = f'{S3_BUCKET}/out/metaanalysis/{args.meta_type}/ancestry-clumped{ancestry_path}'
 
     # initialize spark session
     spark = SparkSession.builder.appName('bottom-line').getOrCreate()
 
     # load the clumped plink output and all association data
-    clumps = spark.read.json(clumpdir)
-    assocs = spark.read.json(srcdir)
+    if not check_clump_error(clumpdir):
+        clumps = spark.read.json(f'{clumpdir}/*.json')
+        assocs = spark.read.json(srcdir)
 
-    # merge with trans-ethnic, association data and sort
-    clumps = clumps.join(assocs, ['varId', 'phenotype'])
-    clumps = clumps.sort(['clump', 'pValue'])
+        # merge with trans-ethnic, association data and sort
+        clumps = clumps.join(assocs, ['varId', 'phenotype'])
+        clumps = clumps.sort(['clump', 'pValue'])
 
-    # drop duplicate clumps, which leaves only the lead SNPs
-    lead_snps = clumps.dropDuplicates(['clump']) \
-        .select(col('varId'), lit(True).alias('leadSNP'))
+        # drop duplicate clumps, which leaves only the lead SNPs
+        lead_snps = clumps.dropDuplicates(['clump']) \
+            .select(col('varId'), lit(True).alias('leadSNP'))
 
-    # join the lead SNPs back with the clumps, set missing as not lead SNPs
-    clumps = clumps.join(lead_snps, on='varId', how='left')
-    clumps = clumps.na.fill({'leadSNP': False})
+        # join the lead SNPs back with the clumps, set missing as not lead SNPs
+        clumps = clumps.join(lead_snps, on='varId', how='left')
+        clumps = clumps.na.fill({'leadSNP': False})
 
-    # get the lead SNPs again, this time with the beta
-    lead_snps = clumps.filter(clumps.leadSNP == True) \
-        .select(clumps.clump, clumps.beta.alias('alignment'))
+        # get the lead SNPs again, this time with the beta
+        lead_snps = clumps.filter(clumps.leadSNP == True) \
+            .select(clumps.clump, clumps.beta.alias('alignment'))
 
-    # calculate the alignment direction for each of the SNPs in the clumps
-    clumps = clumps.join(lead_snps, on='clump')
-    clumps = clumps.withColumn('alignment', signum(clumps.beta * clumps.alignment))
+        # calculate the alignment direction for each of the SNPs in the clumps
+        clumps = clumps.join(lead_snps, on='clump')
+        clumps = clumps.withColumn('alignment', signum(clumps.beta * clumps.alignment))
 
-    # output lead SNPs
-    clumps.write \
-        .mode('overwrite') \
-        .json(outdir)
+        # output lead SNPs
+        clumps.write \
+            .mode('overwrite') \
+            .json(outdir)
 
     # done
     spark.stop()

--- a/bottom-line/src/main/scala/ClumpedAssociationsStage.scala
+++ b/bottom-line/src/main/scala/ClumpedAssociationsStage.scala
@@ -11,18 +11,30 @@ import org.broadinstitute.dig.aws.Ec2.Strategy
 class ClumpedAssociationsStage(implicit context: Context) extends Stage {
   import MemorySize.Implicits._
 
-  val transEthnic = Input.Source.Success("out/metaanalysis/bottom-line/trans-ethnic/*/")
-  val ancestrySpecific = Input.Source.Success("out/metaanalysis/bottom-line/ancestry-specific/*/*/")
+  val transEthnic = Input.Source.Success("out/metaanalysis/*/trans-ethnic/*/")
+  val ancestrySpecific = Input.Source.Success("out/metaanalysis/*/ancestry-specific/*/*/")
   val snps: Input.Source       = Input.Source.Success("out/varianteffect/snp/")
+
+  val paramTypes: Map[String, Seq[String]] = Map(
+    "bottom-line" -> Seq("portal", "analysis"),
+    "naive" -> Seq("analysis"),
+    "min_p" -> Seq("analysis"),
+    "largest" -> Seq("analysis")
+  )
 
   /** The output of meta-analysis is the input for top associations. */
   override val sources: Seq[Input.Source] = Seq(transEthnic, ancestrySpecific, snps)
 
   /** Process top associations for each phenotype. */
   override val rules: PartialFunction[Input, Outputs] = {
-    case transEthnic(phenotype) => Outputs.Named(phenotype)
-    case ancestrySpecific(phenotype, ancestry) =>
-      Outputs.Named(s"$phenotype/${ancestry.split("ancestry=").last}")
+    case transEthnic(metaType, phenotype) =>
+      Outputs.Named(paramTypes(metaType).map { paramType =>
+        s"$metaType/$paramType/$phenotype"
+      }: _*)
+    case ancestrySpecific(metaType, phenotype, ancestry) =>
+      Outputs.Named(paramTypes(metaType).map { paramType =>
+        s"$metaType/$paramType/$phenotype/${ancestry.split("ancestry=").last}"
+      }: _*)
     case snps() => Outputs.All
   }
 
@@ -38,8 +50,10 @@ class ClumpedAssociationsStage(implicit context: Context) extends Stage {
   override def make(output: String): Job = {
     // run clumping and then join with bottom line
     val flags = output.split("/").toSeq match {
-      case Seq(phenotype) => Seq(s"--phenotype=$phenotype", s"--ancestry=Mixed")
-      case Seq(phenotype, ancestry) => Seq(s"--phenotype=$phenotype", s"--ancestry=$ancestry")
+      case Seq(metaType, paramType, phenotype) =>
+        Seq(s"--phenotype=$phenotype", s"--ancestry=TE", s"--meta-type=$metaType", s"--param-type=$paramType")
+      case Seq(metaType, paramType, phenotype, ancestry) =>
+        Seq(s"--phenotype=$phenotype", s"--ancestry=$ancestry", s"--meta-type=$metaType", s"--param-type=$paramType")
     }
 
     val steps = Seq(
@@ -47,19 +61,5 @@ class ClumpedAssociationsStage(implicit context: Context) extends Stage {
       Job.PySpark(resourceUri("clumpedAssociations.py"), flags:_*)
     )
     new Job(steps)
-  }
-
-  /** Nuke the staging directories before the job runs.
-    */
-  override def prepareJob(output: String): Unit = {
-    output.split("/").toSeq match {
-      case Seq(phenotype) =>
-        context.s3.rm(s"out/metaanalysis/staging/clumped/$phenotype/")
-        context.s3.rm(s"out/metaanalysis/staging/plink/$phenotype/")
-      case Seq(phenotype, ancestry) =>
-        context.s3.rm(s"out/metaanalysis/staging/ancestry-clumped/$phenotype/ancestry=$ancestry")
-        context.s3.rm(s"out/metaanalysis/staging/ancestry-plink/$phenotype/ancestry=$ancestry")
-    }
-
   }
 }


### PR DESCRIPTION
This does two things:

(1) It adds the concept of "analysis" clumping runs which will be used in the future to determine the effectiveness of Bottom-Line and display it on the portal.

(2) It fixes a major bug in the way we determine rare variant overlaps in the common clumps

When running the portal release in March 2024 I am not running the analysis, that will be run in full between March and June