### PR TITLE
[Intake] Config for project

### DIFF
--- a/basset/built.sbt
+++ b/basset/built.sbt
@@ -1,5 +1,5 @@
 val Versions = new {
-  val Aggregator = "0.3.3-SNAPSHOT"
+  val Aggregator = "0.3.4-SNAPSHOT"
   val Scala      = "2.13.5"
 }
 

--- a/bioindex/built.sbt
+++ b/bioindex/built.sbt
@@ -1,5 +1,5 @@
 val Versions = new {
-  val Aggregator = "0.3.3-SNAPSHOT"
+  val Aggregator = "0.3.4-SNAPSHOT"
   val Scala      = "2.13.5"
 }
 

--- a/bottom-line/built.sbt
+++ b/bottom-line/built.sbt
@@ -1,5 +1,5 @@
 val Versions = new {
-  val Aggregator = "0.3.3-SNAPSHOT"
+  val Aggregator = "0.3.4-SNAPSHOT"
   val Scala      = "2.13.5"
 }
 

--- a/burden-binning/built.sbt
+++ b/burden-binning/built.sbt
@@ -1,5 +1,5 @@
 val Versions = new {
-  val Aggregator = "0.3.3-SNAPSHOT"
+  val Aggregator = "0.3.4-SNAPSHOT"
   val Scala      = "2.13.5"
 }
 

--- a/config.json
+++ b/config.json
@@ -1,5 +1,6 @@
 {
     "aws": {
+        "project": "portal",
         "input": {
             "bucket": "dig-analysis-data"
         },

--- a/gene-associations/built.sbt
+++ b/gene-associations/built.sbt
@@ -1,5 +1,5 @@
 val Versions = new {
-  val Aggregator = "0.3.3-SNAPSHOT"
+  val Aggregator = "0.3.4-SNAPSHOT"
   val Scala = "2.13.2"
 }
 

--- a/huge/built.sbt
+++ b/huge/built.sbt
@@ -1,5 +1,5 @@
 val Versions = new {
-  val Aggregator = "0.3.3-SNAPSHOT"
+  val Aggregator = "0.3.4-SNAPSHOT"
   val Scala      = "2.13.10"
 }
 

--- a/intake/built.sbt
+++ b/intake/built.sbt
@@ -1,5 +1,5 @@
 val Versions = new {
-  val Aggregator = "0.3.3-SNAPSHOT"
+  val Aggregator = "0.3.4-SNAPSHOT"
   val Scala = "2.13.2"
 }
 

--- a/ldsc/built.sbt
+++ b/ldsc/built.sbt
@@ -1,5 +1,5 @@
 val Versions = new {
-  val Aggregator = "0.3.3-SNAPSHOT"
+  val Aggregator = "0.3.4-SNAPSHOT"
   val Scala      = "2.13.5"
 }
 

--- a/magma/built.sbt
+++ b/magma/built.sbt
@@ -1,5 +1,5 @@
 val Versions = new {
-  val Aggregator = "0.3.3-SNAPSHOT"
+  val Aggregator = "0.3.4-SNAPSHOT"
   val Scala      = "2.13.5"
 }
 

--- a/vep/built.sbt
+++ b/vep/built.sbt
@@ -1,5 +1,5 @@
 val Versions = new {
-  val Aggregator = "0.3.3-SNAPSHOT"
+  val Aggregator = "0.3.4-SNAPSHOT"
   val Scala      = "2.13.5"
 }
 


### PR DESCRIPTION
Adds new fields for the config to comply with built.sbt version 0.3.4. Updates all current version to 0.3.4. Swapping to use the new envvars will happen in several subsequent steps with testing on private portal data